### PR TITLE
Keep the dashboard responsive as data grows

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -64,6 +64,10 @@ for (const stmt of [
   `CREATE INDEX IF NOT EXISTS idx_spans_traceId_startNano ON spans(traceId, startNano)`,
   `CREATE INDEX IF NOT EXISTS idx_spans_severity          ON spans(severity)`,
   `CREATE INDEX IF NOT EXISTS idx_spans_harness           ON spans(harness)`,
+  // Time-ordered reads (recent-N graph window, time-range search) sort/filter
+  // on startNano/endNano; these let SQLite use an index instead of a full scan.
+  `CREATE INDEX IF NOT EXISTS idx_spans_startNano         ON spans(startNano)`,
+  `CREATE INDEX IF NOT EXISTS idx_spans_endNano           ON spans(endNano)`,
   `CREATE INDEX IF NOT EXISTS idx_alerts_traceId          ON alerts(traceId)`,
   `CREATE INDEX IF NOT EXISTS idx_alerts_dismissed_ts     ON alerts(dismissed, ts)`,
 ]) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -148,6 +148,27 @@ const deleteAllSpans    = db.prepare(`DELETE FROM spans`);
 const deleteAllSessions = db.prepare(`DELETE FROM sessions`);
 const getAllSpans        = db.prepare(`SELECT * FROM spans`);
 
+// How many of the most-recent spans the live graph renders. Older spans are NOT
+// deleted — they remain fully available via Search, Sessions, and history. This
+// only bounds how much the graph loads, relays out, and tracks as React node
+// state, which is the dominant cost as the spans table grows. Override with
+// CLAUDESEC_GRAPH_LIMIT (any positive integer).
+const GRAPH_LIMIT = (() => {
+  const n = parseInt(String(process.env.CLAUDESEC_GRAPH_LIMIT ?? ''), 10);
+  return Number.isFinite(n) && n > 0 ? n : 2000;
+})();
+
+// Select the most-recent N spans (by start time) but return them in ascending
+// order, so downstream node ordering matches a full-table read of the window.
+const getRecentSpans = db.prepare(`
+  SELECT * FROM (
+    SELECT * FROM spans ORDER BY startNano DESC LIMIT ?
+  ) ORDER BY startNano ASC
+`);
+
+// Total span count — used only to decide whether the graph window is truncating.
+const countSpans = db.prepare(`SELECT COUNT(*) AS c FROM spans`);
+
 const getWatchOffset = db.prepare(`SELECT offset FROM watch_offsets WHERE path = ?`);
 const setWatchOffset = db.prepare(`
   INSERT INTO watch_offsets (path, offset, updatedAt) VALUES (?, ?, ?)
@@ -1022,9 +1043,20 @@ function recordToEdge(r: SpanRecord) {
 }
 
 function buildGraph(sessionFilter?: string) {
-  const records: SpanRecord[] = sessionFilter
-    ? (db.prepare('SELECT * FROM spans WHERE traceId = ?').all(sessionFilter) as SpanRecord[])
-    : (getAllSpans.all() as SpanRecord[]);
+  // A single session is already bounded, so it loads in full. The unscoped graph
+  // loads only the most-recent N spans (see GRAPH_LIMIT) to keep both the server
+  // build and the frontend relayout fast. `windowed` tells the UI when older
+  // spans exist beyond the window — they are still searchable, never deleted.
+  let records: SpanRecord[];
+  let windowed = false;
+  let total = 0;
+  if (sessionFilter) {
+    records = db.prepare('SELECT * FROM spans WHERE traceId = ?').all(sessionFilter) as SpanRecord[];
+  } else {
+    total   = (countSpans.get() as { c: number }).c;
+    records = getRecentSpans.all(GRAPH_LIMIT) as SpanRecord[];
+    windowed = total > records.length;
+  }
 
   const presentHarnesses = [...new Set(records.map(r => r.harness))];
   let rootNodes: object[];
@@ -1044,7 +1076,15 @@ function buildGraph(sessionFilter?: string) {
     });
   }
 
-  return { nodes: [...rootNodes, ...records.map(recordToNode)], edges: records.map(recordToEdge) };
+  return {
+    nodes: [...rootNodes, ...records.map(recordToNode)],
+    edges: records.map(recordToEdge),
+    // Graph windowing metadata — backward compatible (consumers may ignore it).
+    windowed,
+    shown: records.length,
+    total: sessionFilter ? records.length : total,
+    limit: GRAPH_LIMIT,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1677,27 +1717,44 @@ async function startServer() {
     const session = String(req.query.session ?? '').trim();
     const offset  = Math.max(0, parseInt(String(req.query.offset ?? '0'), 10) || 0);
 
-    let sql = 'SELECT * FROM spans WHERE 1=1';
+    let sql = 'SELECT s.* FROM spans s WHERE 1=1';
     const params: unknown[] = [];
 
-    if (session) { sql += ' AND traceId = ?'; params.push(session); }
+    if (session) { sql += ' AND s.traceId = ?'; params.push(session); }
 
     if (q) {
       if (q.includes('=')) {
+        // Structured key=value lookup. FTS tokenizes the JSON and loses the
+        // key↔value association, so this targeted match stays on LIKE.
         const eqIdx = q.indexOf('=');
         const key   = q.slice(0, eqIdx).trim();
         const val   = q.slice(eqIdx + 1).trim();
-        sql += ' AND (attributes LIKE ? OR name LIKE ?)';
+        sql += ' AND (s.attributes LIKE ? OR s.name LIKE ?)';
         params.push(`%"${key}":"${val}%`, `%${val}%`);
       } else {
-        sql += ' AND (name LIKE ? OR attributes LIKE ? OR reason LIKE ?)';
-        params.push(`%${q}%`, `%${q}%`, `%${q}%`);
+        // Free-text search routes through the FTS5 index instead of a leading-
+        // wildcard LIKE (which forces a full table scan). Mirrors the proven
+        // /api/search/fts pattern: split on whitespace, prefix-match each term.
+        const terms = q.replace(/["']/g, ' ').split(/\s+/).filter(Boolean);
+        if (terms.length === 0) {
+          res.json({ spans: [], offset, hasMore: false });
+          return;
+        }
+        const ftsQuery = terms.map(t => `"${t}"*`).join(' ');
+        sql += ' AND s.spanId IN (SELECT spanId FROM spans_fts WHERE spans_fts MATCH ?)';
+        params.push(ftsQuery);
       }
     }
 
-    sql += ' ORDER BY startNano ASC LIMIT 500 OFFSET ?';
+    sql += ' ORDER BY s.startNano ASC LIMIT 500 OFFSET ?';
     params.push(offset);
-    const spans = db.prepare(sql).all(...params) as SpanRecord[];
+    let spans: SpanRecord[];
+    try {
+      spans = db.prepare(sql).all(...params) as SpanRecord[];
+    } catch {
+      // Malformed FTS expression → return empty rather than 500.
+      spans = [];
+    }
     res.json({ spans, offset, hasMore: spans.length === 500 });
   });
 

--- a/server/routes/search.ts
+++ b/server/routes/search.ts
@@ -26,59 +26,56 @@ function buildSearchQuery(opts: {
   const conditions: string[] = [];
   const params: unknown[]    = [];
 
-  // Tag filter — join against span_tags
-  let fromClause = 'spans';
+  // Spans are aliased `s` so a free-text query can JOIN the FTS index by spanId
+  // without column ambiguity.
   if (opts.tag) {
     const tagClean = opts.tag.trim().toLowerCase();
-    conditions.push('spanId IN (SELECT spanId FROM span_tags WHERE tag = ?)');
+    conditions.push('s.spanId IN (SELECT spanId FROM span_tags WHERE tag = ?)');
     params.push(tagClean);
   }
 
-  // FTS5 match — fall back to LIKE if query is empty
+  // Free-text query restricts to spans the FTS5 index matched. We push the MATCH
+  // as a correlated subquery instead of materializing every matching spanId up
+  // front — the latter is unbounded and gets slow as the spans table grows.
   if (opts.q) {
-    try {
-      const escaped = '"' + opts.q.replace(/"/g, '""') + '"';
-      const ftsIds  = (db.prepare('SELECT spanId FROM spans_fts WHERE spans_fts MATCH ?').all(escaped) as { spanId: string }[]).map(r => r.spanId);
-      if (ftsIds.length === 0) return { spans: [], total: 0 };
-      const ph = ftsIds.map(() => '?').join(',');
-      conditions.push(`spanId IN (${ph})`);
-      params.push(...ftsIds);
-    } catch {
-      // FTS5 syntax error → fall back to LIKE
-      const like = `%${opts.q}%`;
-      conditions.push('(name LIKE ? OR attributes LIKE ?)');
-      params.push(like, like);
-    }
+    const escaped = '"' + opts.q.replace(/"/g, '""') + '"';
+    conditions.push('s.spanId IN (SELECT spanId FROM spans_fts WHERE spans_fts MATCH ?)');
+    params.push(escaped);
   }
 
   if (opts.severity && opts.severity !== 'all') {
-    conditions.push('severity = ?');
+    conditions.push('s.severity = ?');
     params.push(opts.severity);
   }
   if (opts.harness) {
-    conditions.push('harness = ?');
+    conditions.push('s.harness = ?');
     params.push(opts.harness);
   }
   if (opts.from) {
     try {
       const nanoFrom = String(BigInt(new Date(opts.from).getTime()) * 1_000_000n);
-      conditions.push('startNano >= ?');
+      conditions.push('s.startNano >= ?');
       params.push(nanoFrom);
     } catch {}
   }
   if (opts.to) {
     try {
       const nanoTo = String(BigInt(new Date(opts.to).getTime()) * 1_000_000n);
-      conditions.push('startNano <= ?');
+      conditions.push('s.startNano <= ?');
       params.push(nanoTo);
     } catch {}
   }
 
   const where  = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
-  const total  = (db.prepare(`SELECT COUNT(*) as c FROM ${fromClause} ${where}`).get(...params) as any).c as number;
-  const spans  = db.prepare(`SELECT * FROM ${fromClause} ${where} ORDER BY startNano DESC LIMIT ? OFFSET ?`)
-    .all(...params, opts.limit, opts.offset) as SpanRecord[];
-  return { spans, total };
+  try {
+    const total  = (db.prepare(`SELECT COUNT(*) as c FROM spans s ${where}`).get(...params) as any).c as number;
+    const spans  = db.prepare(`SELECT s.* FROM spans s ${where} ORDER BY s.startNano DESC LIMIT ? OFFSET ?`)
+      .all(...params, opts.limit, opts.offset) as SpanRecord[];
+    return { spans, total };
+  } catch {
+    // Malformed FTS expression → no matches rather than a 500.
+    return { spans: [], total: 0 };
+  }
 }
 
 export function registerSearchRoutes(app: Express, _ctx: RouteContext): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,9 @@ export default function App() {
   // ── Graph state ───────────────────────────────────────────────────────────
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  // When the unscoped graph shows only the most-recent N spans (older spans stay
+  // searchable, never deleted), the server reports a window so we can say so.
+  const [graphWindow, setGraphWindow] = useState<{ shown: number; total: number } | null>(null);
 
   // ── UI state ──────────────────────────────────────────────────────────────
   const [activeTab, setActiveTab]           = useState<Tab>('timeline');
@@ -306,10 +309,11 @@ export default function App() {
     const graphUrl = activeSession ? `/api/graph?session=${encodeURIComponent(activeSession)}` : '/api/graph';
     fetch(graphUrl)
       .then(r => r.json())
-      .then(({ nodes: n, edges: e }: { nodes: Node[]; edges: Edge[] }) => {
+      .then(({ nodes: n, edges: e, windowed, shown, total }: { nodes: Node[]; edges: Edge[]; windowed?: boolean; shown?: number; total?: number }) => {
         setNodes(applyLayout(n, e, layoutMode));
         setEdges(e);
         syncWorkflows(n);
+        setGraphWindow(windowed ? { shown: shown ?? n.length, total: total ?? 0 } : null);
       });
     fetchSessions();
     fetchAlertCount();
@@ -358,7 +362,7 @@ export default function App() {
 
   // Socket events
   useEffect(() => {
-    const handleGraphUpdate = ({ nodes: n, edges: e }: { nodes: Node[]; edges: Edge[] }) => {
+    const handleGraphUpdate = ({ nodes: n, edges: e, windowed, shown, total }: { nodes: Node[]; edges: Edge[]; windowed?: boolean; shown?: number; total?: number }) => {
       // When scoped to a session, re-fetch the scoped graph instead of using the broadcast
       if (activeSession) {
         fetch(`/api/graph?session=${encodeURIComponent(activeSession)}`)
@@ -367,12 +371,14 @@ export default function App() {
             setNodes(applyLayout(sn, se, layoutMode));
             setEdges(se);
             syncWorkflows(sn);
+            setGraphWindow(null); // a single session is shown in full
           });
         return;
       }
       setNodes(applyLayout(n, e, layoutMode));
       setEdges(e);
       syncWorkflows(n);
+      setGraphWindow(windowed ? { shown: shown ?? n.length, total: total ?? 0 } : null);
 
       // Desktop notifications for new HIGH severity spans
       if (notifyEnabledRef.current) {
@@ -1316,6 +1322,12 @@ export default function App() {
                   <X className="w-3.5 h-3.5" />
                 </button>
               </div>
+            )}
+            {graphWindow && !activeSession && (
+              <p className="mx-4 mt-1 mb-1 text-[11px]" style={{ color: 'var(--cs-text-faint)' }}>
+                Showing the most recent {graphWindow.shown.toLocaleString()} events.
+                Older events remain available via Search and Sessions.
+              </p>
             )}
             <Timeline
               workflows={visibleWorkflows}

--- a/src/CostTab.tsx
+++ b/src/CostTab.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { DollarSign, TrendingUp, Cpu, HelpCircle, Webhook, CheckCircle, XCircle, AlertTriangle, Database, Trash2, RefreshCw, Info } from 'lucide-react';
 import { socket } from './socket';
 import { ExperimentalBadge } from './ExperimentalBadge';
+import { useDebouncedCallback } from './lib/useDebouncedCallback';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -401,12 +402,16 @@ export function CostTab() {
   const load = () =>
     fetch('/api/costs').then(r => r.json()).then(setData).catch(() => {});
 
+  // `/api/costs` runs a full table scan. Refresh on the coalesced `graph-update`
+  // signal (not per `span-added`, which would re-scan once for EVERY span in a
+  // batch), and debounce so a burst of updates triggers a single refetch.
+  const debouncedLoad = useDebouncedCallback(load);
+
   useEffect(() => {
     load();
-    socket.on('graph-update', load);
-    socket.on('span-added', load);
-    return () => { socket.off('graph-update', load); socket.off('span-added', load); };
-  }, []);
+    socket.on('graph-update', debouncedLoad);
+    return () => { socket.off('graph-update', debouncedLoad); };
+  }, [debouncedLoad]);
 
   useEffect(() => {
     try { localStorage.setItem(PLAN_STORAGE_KEY, plan); } catch {}

--- a/src/HeatmapTab.tsx
+++ b/src/HeatmapTab.tsx
@@ -5,6 +5,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { Flame } from 'lucide-react';
 import { socket } from './socket';
+import { useDebouncedCallback } from './lib/useDebouncedCallback';
 
 interface Cell { spans: number; threats: number }
 interface HeatmapData {
@@ -70,11 +71,16 @@ export function HeatmapTab() {
       .catch(() => setLoading(false));
   }, [view]);
 
+  // Recomputing the heatmap scans every span. Debounce the socket-driven
+  // refresh so a burst of `graph-update` events collapses into one refetch;
+  // the initial load below stays immediate so first paint isn't delayed.
+  const debouncedFetch = useDebouncedCallback(fetchHeatmap);
+
   useEffect(() => {
     fetchHeatmap();
-    socket.on('graph-update', fetchHeatmap);
-    return () => { socket.off('graph-update', fetchHeatmap); };
-  }, [fetchHeatmap]);
+    socket.on('graph-update', debouncedFetch);
+    return () => { socket.off('graph-update', debouncedFetch); };
+  }, [fetchHeatmap, debouncedFetch]);
 
   if (loading) {
     return (

--- a/src/OrchestrationTab.tsx
+++ b/src/OrchestrationTab.tsx
@@ -5,6 +5,7 @@ import { CommandAuditTab } from './CommandAuditTab';
 import { FileAccessPanel } from './FileAccessPanel';
 import { ExperimentalBadge } from './ExperimentalBadge';
 import { useListControls, FilterBar, ListFooter, type FacetConfig } from './FilterControls';
+import { useDebouncedCallback } from './lib/useDebouncedCallback';
 
 // ── Interfaces ────────────────────────────────────────────────────────────────
 
@@ -262,11 +263,16 @@ export function OrchestrationTab() {
       .then((d: OrchData) => setData(d))
       .catch(() => {});
 
+  // `/api/orchestration` aggregates across all spans. Debounce the socket-driven
+  // refresh so a burst of `graph-update` events triggers one refetch, not many;
+  // the initial fetch stays immediate.
+  const debouncedFetch = useDebouncedCallback(fetchData);
+
   useEffect(() => {
     fetchData();
-    socket.on('graph-update', fetchData);
-    return () => { socket.off('graph-update', fetchData); };
-  }, []);
+    socket.on('graph-update', debouncedFetch);
+    return () => { socket.off('graph-update', debouncedFetch); };
+  }, [debouncedFetch]);
 
   const { agents, edges, tools, spawnTree } = data;
   const positions = agentPositions(agents.length);

--- a/src/lib/useDebouncedCallback.ts
+++ b/src/lib/useDebouncedCallback.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Returns a stable, trailing-debounced wrapper around `callback`.
+ *
+ * Why: the heavy dashboard tabs (Cost, Heatmap, Orchestration) refetch on every
+ * `graph-update` socket event. A single OTLP batch can fan out into many updates,
+ * and each refetch triggers a full server-side table scan. Debouncing collapses a
+ * burst of updates into ONE trailing refetch, so the UI still refreshes after the
+ * burst settles but does not stampede the server while spans are streaming in.
+ *
+ * The returned function keeps a stable identity across renders so it can be passed
+ * straight to `socket.on(...)` / `socket.off(...)` and unbind cleanly. Internally it
+ * always invokes the LATEST `callback`, so closures over changing state (e.g. the
+ * current view) never go stale.
+ */
+export function useDebouncedCallback<A extends unknown[]>(
+  callback: (...args: A) => void,
+  delayMs = 700,
+): (...args: A) => void {
+  const callbackRef = useRef(callback);
+  const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Always point at the freshest callback so debounced calls never run stale logic.
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // Clear any pending invocation when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return useCallback(
+    (...args: A) => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        callbackRef.current(...args);
+      }, delayMs);
+    },
+    [delayMs],
+  );
+}


### PR DESCRIPTION
## Summary

Keep the dashboard responsive as the spans table grows — **without deleting any data**.

## Changes

- **Stop the refetch storms.** The Cost tab was re-scanning the entire spans table on *every* ingested span; it now refreshes only on the coalesced graph update, debounced. Heatmap and Orchestration refetches are debounced too, so a burst of updates triggers one refresh instead of many.
- **Index time-ordered reads.** Add `idx_spans_startNano` and `idx_spans_endNano`.
- **Window the graph.** The graph view now renders the most-recent N events (default `2000`, overridable via `CLAUDESEC_GRAPH_LIMIT`) with a clear "showing recent events" note. Older events stay fully available via Search and Sessions — nothing is deleted, and cost/heatmap/export still see all data.
- **Faster search.** Route span search through the FTS index instead of an unindexed `LIKE '%…%'` scan.

## Verification

`pnpm preflight` (lint, test, build, consistency, audit) and a local CodeQL run pass.
