### PR TITLE
Align the documentation with the current codebase

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,15 +92,15 @@ Example: `feat: add prompt-injection detection rule`
 
 ## Adding a New Threat Rule
 
-Threat-detection rules live in `server.ts` in the `SEVERITY_RULES` array. Each rule is an object with three fields:
+The core threat-detection rules live in `server/detection.ts` in the `CORE_SEVERITY_RULES` array; the extended rule set lives in `server/severityRulesExtra.ts`. Each rule is an object with three fields:
 
 ```ts
-{ pattern: /your-regex/i, severity: 'HIGH' | 'MEDIUM' | 'LOW', label: 'Short description of what this rule detects' }
+{ pattern: /your-regex/i, severity: 'high' | 'medium' | 'low', label: 'Short description of what this rule detects' }
 ```
 
 Steps:
-1. Open `server.ts` and locate `SEVERITY_RULES`.
-2. Add your entry in the appropriate severity group (HIGH first, then MEDIUM, then LOW).
+1. Open `server/detection.ts` and locate `CORE_SEVERITY_RULES` (or add to `server/severityRulesExtra.ts` for the extended set).
+2. Add your entry in the appropriate severity group (high first, then medium, then low).
 3. Include a comment explaining what the rule targets.
 4. Add a matching entry to the threat-detection table in `README.md`.
 5. Test it with a `curl` POST to `/v1/traces`, or by running a real agent whose action matches the pattern.

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ The following are planned future work — not yet shipped:
 ClaudeSec reads sensitive material (your agents' commands, prompts, and file contents), so it is local-first by construction:
 
 - **Loopback only** — the server binds `127.0.0.1` by default. Set `CLAUDESEC_HOST=0.0.0.0` (and a real `CLAUDESEC_TOKEN`) only if you deliberately want LAN/network access.
-- **No egress** — nothing is sent anywhere. The only optional outbound paths are `OTEL_FORWARD_URL` and the opt-in `CLAUDESEC_JUDGE_URL` — both off unless you set them, both SSRF-blocked for private ranges (re-checked on every retry to defeat DNS rebinding).
+- **No egress** — nothing is sent anywhere. The only optional outbound paths are `OTEL_FORWARD_URL`, `CLAUDESEC_WEBHOOK_URL`, and the opt-in `CLAUDESEC_JUDGE_URL` — all off unless you set them. `OTEL_FORWARD_URL` and `CLAUDESEC_WEBHOOK_URL` are SSRF-blocked for private and loopback ranges (re-checked on every retry to defeat DNS rebinding); `CLAUDESEC_JUDGE_URL` is SSRF-guarded for non-loopback URLs but allows loopback so the judge can run fully on-device.
 - **Owner-only database** — `spans.db` is created with `0600` permissions.
 - **Secret scrubbing on by default** — known secret shapes, home paths, usernames, and emails are redacted before anything is persisted, broadcast, or exported. Disable with `CLAUDESEC_DISABLE_SCRUB=1`.
 

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -9,8 +9,12 @@ icon: "sitemap"
 ClaudeSec is a local AI agent observability dashboard. It receives OpenTelemetry traces from running AI agents, evaluates every span against a threat detection engine, persists results to SQLite, and streams live updates to a React frontend over Socket.io.
 
 ```
-AI Agent
-  ↓  OTLP JSON (POST /v1/traces)
+Local agents (Claude Code / Copilot CLI / Codex)
+  ↓  tails on-disk .jsonl transcripts (default, zero-config)
+transcriptWatcher.ts ─┐
+                      ├─→ ingestSpan()
+Remote / CI agents ───┘   (same pipeline)
+  ↑  OTLP JSON (POST /v1/traces)
 server/index.ts (Express)
   ├─ Rate limiting (token bucket per IP)
   ├─ Threat detection (detectSeverity)
@@ -21,6 +25,8 @@ server/index.ts (Express)
         ↓
    src/App.tsx (React 19 + Tailwind CSS 4)
 ```
+
+The default local path is the **transcript watcher**, which tails each agent's on-disk session files and needs no configuration. The OTLP endpoint (`POST /v1/traces`) is the path for remote and CI agents ClaudeSec can't read from disk. Both feed the same `ingestSpan()` pipeline, so local and remote activity land in one dashboard.
 
 ---
 
@@ -87,7 +93,7 @@ Runs per affected session after each OTLP batch. Does not block the HTTP respons
 |---------|-----------|----------|
 | Token spike | Latest span uses >4× session average input tokens, and >2000 tokens | `medium` |
 | Threat burst | ≥3 threats in the last 10 spans of a session | `high` |
-| Excessive tool calls | >100 total tool calls in a session (flagged once per 50 excess) | `low` |
+| Excessive tool calls | >100 total tool calls in a session (fires once, then deduped for 30 minutes) | `low` |
 | Off-hours activity | Agent active between 00:00–05:59 local time | `low` |
 
 Each anomaly is deduplicated within a cooldown window (5–60 minutes) to avoid alert flooding.
@@ -158,6 +164,8 @@ Stale buckets (idle for >5 minutes) are evicted every 60 seconds.
 ## Graph API (headless)
 
 The graph endpoints (`GET /api/graph`, `/api/graph/mermaid`, `/api/graph/dot`) remain available as a headless API for programmatic access and export. They return span dependency data with Dagre-computed positions, suitable for rendering in external tools (Mermaid, Graphviz) or custom integrations. There is no graph UI tab in the dashboard.
+
+The graph renders only the **most-recent N events** — bounded by `CLAUDESEC_GRAPH_LIMIT` (default 2000) — so it stays fast as the database grows. Older events are **not** deleted; they remain available through Search and Sessions. See [Data retention](/explanation/retention) for the full capacity model.
 
 ---
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## Unreleased
+
+### Added
+
+- **One-command start** — `./start.sh` brings up the dashboard in a single command:
+  it installs dependencies if needed, starts the foreground server, tails your
+  on-disk agent transcripts, and tells you which agents it can see. `./start.sh --docker`
+  runs the headless Docker deployment (OTLP-only).
+- **Isolated demo container** — an on-demand container pre-seeded with synthetic
+  data on its own database volume, for showing ClaudeSec without exposing real
+  telemetry. Start it with `./start.sh --demo` (or `docker compose --profile demo up`):
+  prod stays on `:3000` with your real data, and the demo runs on `:3001` (override
+  with `DEMO_PORT`) seeded with synthetic sessions that fire real detection rules.
+  The demo container is physically isolated from prod — its own volume, no in-app
+  toggle, no per-row tagging.
+- **Local release flow** — `scripts/release.sh <patch|minor|major>` cuts a release
+  from a maintainer's machine: it runs the full local CI (`pnpm preflight`), bumps the
+  version everywhere it is recorded, writes the changelog, re-runs the consistency
+  gate, and — only after you confirm — commits, tags, pushes, and publishes the
+  GitHub Release. It refuses to run on a dirty or out-of-date tree and never
+  force-pushes.
+
+### Changed
+
+- **Graph performance** — the live graph now renders only the most-recent N events,
+  bounded by `CLAUDESEC_GRAPH_LIMIT` (default 2000), so it stays responsive as the
+  database grows. Older events are not deleted — they remain available through
+  Search and Sessions. See [Data retention](/explanation/retention).
+
+---
+
 ## 1.0.0 — Initial public release
 
 First production-ready release of ClaudeSec under the **AGPL-3.0-only** license.
@@ -34,7 +65,7 @@ interactive dashboard — all without any data leaving your machine.
 - Per-harness coloured indicators and filter chips in the dashboard.
 - Zero-config transcript watcher (`transcriptWatcher.ts`) that tails on-disk session transcripts
   for Claude Code, GitHub Copilot CLI, and Codex with no environment variables and no agent restart.
-- Interactive CLI setup wizard (`npx claudesec init` / `pnpm run init`).
+- Interactive CLI setup wizard (`node cli/init.mjs` / `pnpm run init`).
 
 **Threat detection**
 
@@ -140,7 +171,7 @@ interactive dashboard — all without any data leaving your machine.
 - Drawer sidebar (below `lg` breakpoint) + bottom tab bar (below `md` breakpoint).
 - Four built-in themes: Midnight, Carbon, Daylight, Paper (saved locally).
 - Accessibility: keyboard navigation and ARIA attributes throughout.
-- First-run welcome screen with `npx claudesec init` auto-setup flow.
+- First-run welcome screen with `node cli/init.mjs` auto-setup flow.
 
 **Observability**
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,14 +72,16 @@
       {
         "group": "How-to guides",
         "pages": [
-          "how-to/remote-agents"
+          "how-to/remote-agents",
+          "how-to/local-llm"
         ]
       },
       {
         "group": "Explanation",
         "pages": [
           "architecture",
-          "explanation/watcher"
+          "explanation/watcher",
+          "explanation/retention"
         ]
       },
       {

--- a/docs/explanation/retention.mdx
+++ b/docs/explanation/retention.mdx
@@ -1,0 +1,60 @@
+---
+title: "Data retention & dashboard capacity"
+description: "What ClaudeSec keeps, how pruning actually works, and how to tune capacity for heavy use."
+---
+
+ClaudeSec is built to **keep your data**. There is no aggressive auto-delete: spans, sessions, and alerts stay in the local SQLite database (`spans.db`) until they cross one of two configured limits, or you prune by hand. This page explains exactly how that works so you can reason about capacity.
+
+## The two limits
+
+| Variable | Default | What it bounds |
+|----------|---------|----------------|
+| `CLAUDESEC_MAX_SPANS` | `50000` | Total span capacity before the **oldest** spans are pruned |
+| `CLAUDESEC_RETENTION_DAYS` | `30` | Sessions (and their spans and alerts) older than this are removed |
+
+Both are generous defaults. Until you exceed them, nothing is deleted.
+
+## How pruning actually works
+
+Pruning runs as a background step **after each OTLP ingest batch** (it is scheduled with `setImmediate`, so it never blocks the ingest response). Each pass does two things:
+
+1. **Age-based pruning.** Sessions whose `createdAt` is older than `CLAUDESEC_RETENTION_DAYS` are removed, along with their spans and alerts.
+2. **Count-based pruning.** If the total span count exceeds `CLAUDESEC_MAX_SPANS`, the **oldest** spans are deleted first — ordered by `startNano` ascending — until the table is back under the limit.
+
+<Note>
+  Count-based pruning runs on the **OTLP ingest path**. The local transcript watcher feeds the same pipeline, but the periodic prune fires off the OTLP batch handler — so a purely-local instance with the watcher running and no OTLP traffic relies on the age-based window and manual pruning to reclaim space.
+</Note>
+
+### The capacity circuit breaker
+
+To protect the database from runaway growth, OTLP ingestion has a circuit breaker: when the span table reaches **90% of `CLAUDESEC_MAX_SPANS`**, new ingestion is rejected with `503 Service Unavailable` until pruning brings the count back down. This is a safety valve, not the normal path — under default settings you are very unlikely to hit it.
+
+## The graph window vs. your full history
+
+The live graph renders only the **most-recent N spans** for speed — controlled by `CLAUDESEC_GRAPH_LIMIT` (default `2000`). This is purely a rendering window: older spans are **not** deleted. They remain fully available through **Search**, **Sessions**, and the history views. Raising or lowering `CLAUDESEC_GRAPH_LIMIT` only changes how much the graph loads and tracks as client state, which is the dominant cost as the table grows.
+
+So: the graph stays fast on a large database, and none of your older data is hidden — just queried instead of drawn.
+
+## Tuning for heavy use
+
+If you run many agents or keep long histories, raise the span ceiling:
+
+```bash
+export CLAUDESEC_MAX_SPANS=200000
+```
+
+Trade-offs to weigh:
+
+- **Disk and memory.** More spans means a larger `spans.db` and a larger FTS index. SQLite handles this well, but the file grows roughly linearly with span count.
+- **Query and prune cost.** Searches and prune passes touch more rows. Day-to-day queries stay fast thanks to the FTS5 index; the periodic prune simply has more to scan.
+- **Graph rendering is unaffected.** Because the graph is bounded by `CLAUDESEC_GRAPH_LIMIT`, a bigger `CLAUDESEC_MAX_SPANS` does not slow the graph down — only Search and Sessions see the larger window.
+
+## Pruning manually
+
+You can reclaim space on demand from the **Cost** screen's Database Health panel, or:
+
+```bash
+curl -X POST http://localhost:3000/api/db-stats/prune
+```
+
+See the [Configuration reference](/reference/config) for every retention and performance variable.

--- a/docs/how-to/local-llm.mdx
+++ b/docs/how-to/local-llm.mdx
@@ -1,0 +1,66 @@
+---
+title: "Use a local LLM as judge"
+description: "Run an on-device model as an optional semantic detector — no data leaves your machine."
+---
+
+ClaudeSec's threat detection is regex-first: every span is scored against the built-in rule library with no model in the loop. The **LLM-as-judge** is an optional second opinion — a model that classifies a piece of agent activity as prompt injection, jailbreak, data exfiltration, or benign, *on top of* the rules.
+
+It is **off by default and on-demand**, and it is designed so you can run it entirely on-device.
+
+## How it works
+
+- **Off by default.** With no `CLAUDESEC_JUDGE_URL` set, the judge makes **zero** network calls — ClaudeSec's "nothing leaves your machine" promise is unchanged.
+- **On-demand, not automatic.** The judge never runs on every span. You invoke it from **Detect → Alerts** with the **Analyze** action on a span (or via `POST /api/judge` with a `text` or `spanId` body). The regex engine stays the only always-on detector.
+- **OpenAI-compatible.** The judge calls a standard `/chat/completions` endpoint, so any server that speaks the OpenAI chat API works — including local runtimes like Ollama and LM Studio.
+- **Loopback is the recommended path.** A loopback judge (`127.0.0.1`, `::1`, or `localhost`) is always allowed — that is the no-egress configuration. Any **non-loopback** URL is forced through the shared SSRF guard, so it cannot be aimed at private ranges or cloud-metadata addresses, even by accident.
+- **Fail-open.** Any error, timeout, bad response, or disabled state is ignored — the judge never throws into a caller and never blocks ingestion or detection.
+
+## Option A — Ollama
+
+[Ollama](https://ollama.com) runs models locally and exposes an OpenAI-compatible API at `http://localhost:11434/v1`.
+
+1. Install Ollama and pull a model:
+
+   ```bash
+   ollama pull llama3.1
+   ```
+
+2. Point ClaudeSec at it and restart the server:
+
+   ```bash
+   export CLAUDESEC_JUDGE_URL=http://localhost:11434/v1
+   export CLAUDESEC_JUDGE_MODEL=llama3.1
+   ```
+
+That is the fully local, no-egress setup: the judge URL is loopback, so it is allowed without passing the public-only SSRF guard, and nothing leaves your machine.
+
+## Option B — LM Studio
+
+[LM Studio](https://lmstudio.ai) serves a downloaded model behind an OpenAI-compatible endpoint at `http://localhost:1234/v1`.
+
+1. Load a model in LM Studio and start its local server.
+2. Point ClaudeSec at it and restart the server:
+
+   ```bash
+   export CLAUDESEC_JUDGE_URL=http://localhost:1234/v1
+   export CLAUDESEC_JUDGE_MODEL=<the-model-id-shown-in-lm-studio>
+   ```
+
+## Running it
+
+Open **Detect → Alerts**, select a span, and use the **Analyze** action. The judge returns a verdict (`malicious`, `suspicious`, or `benign`), a short category, a confidence score, and a one-line rationale. If the judge is not configured, the action reports that it is off — it never silently calls out.
+
+## Judge environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `CLAUDESEC_JUDGE_URL` | — | OpenAI-compatible `/chat/completions` endpoint. **Unset = judge off, no outbound calls.** Loopback allowed; non-loopback is SSRF-guarded |
+| `CLAUDESEC_JUDGE_MODEL` | `llama3.1` | Model name passed in the request |
+| `CLAUDESEC_JUDGE_KEY` | — | Optional bearer key for the endpoint (not needed for local Ollama / LM Studio) |
+| `CLAUDESEC_JUDGE_TIMEOUT_MS` | `8000` | Per-request timeout in milliseconds (capped at 60000) |
+
+<Note>
+  A bare base URL is accepted too — `http://localhost:11434` is treated as OpenAI-compatible and resolved to `/v1/chat/completions`. A URL ending in `/v1` gets `/chat/completions` appended; a full `/chat/completions` URL is used as-is.
+</Note>
+
+The judge is a supplement, never a replacement. The regex rule library remains the source of truth; see [Security Rules](/security/rules) and [Privacy & Security](/security/privacy).

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -17,11 +17,17 @@ No environment variables. No restarting your terminal. Nothing ever leaves your 
 
 ## Install
 
-Clone the repo, install dependencies, and start the dashboard — it begins watching every agent on your machine right away:
+Clone the repo and run the one-command starter — it installs dependencies, starts the dashboard, and begins watching every agent on your machine right away:
 
 ```bash
 git clone https://github.com/aanjaneyasinghdhoni/ClaudeSec.git
 cd ClaudeSec
+./start.sh
+```
+
+Prefer to run the steps yourself? They are:
+
+```bash
 corepack enable
 pnpm install
 pnpm dev
@@ -61,7 +67,7 @@ That's it — open **http://localhost:3000**. See the [Quickstart](/quickstart) 
 ClaudeSec reads sensitive material, so it is built local-first:
 
 - **Loopback only** — the server binds `127.0.0.1` by default.
-- **No egress** — nothing is sent anywhere (the single optional outbound path is `OTEL_FORWARD_URL`, SSRF-blocked for private ranges).
+- **No egress** — nothing is sent anywhere unless you opt in. There are three optional outbound paths, all off unless set: `OTEL_FORWARD_URL` (forward OTLP traces), `CLAUDESEC_WEBHOOK_URL` (alert delivery), and `CLAUDESEC_JUDGE_URL` (the optional LLM-as-judge). All are SSRF-guarded; the judge additionally allows loopback, so it can run fully on-device.
 - **Owner-only database** — `spans.db` is created with `0600` permissions.
 - **Secret scrubbing on by default** — see [Privacy & Security](/security/privacy).
 

--- a/docs/mcp.mdx
+++ b/docs/mcp.mdx
@@ -6,6 +6,14 @@ icon: cpu
 
 ClaudeSec exposes an MCP JSON-RPC endpoint at `POST /mcp`.
 
+## Why an MCP server?
+
+The MCP server makes ClaudeSec's security data queryable **by another AI agent**. Instead of a human reading the dashboard, a triage or incident-response agent can call tools like `get_incident_summary`, `get_alerts`, and `search_spans` over the [Model Context Protocol](https://modelcontextprotocol.io) to pull exactly what it needs — building an incident summary for a trace, fetching high-severity alerts, or searching spans — and reason over it programmatically. It is AI-to-AI: your observability data becomes a tool another agent can use.
+
+<Note>
+  This is the **read/query** side of MCP. To enforce ClaudeSec's rules *on* an agent's MCP tool calls (gating `tools/call` across Codex, Copilot, and Claude Desktop), see the [cross-agent MCP enforcement proxy](/security/enforcement#cross-agent-enforcement-mcp-proxy).
+</Note>
+
 ## Endpoint
 
 ```bash

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -19,9 +19,17 @@ ClaudeSec is zero-config. You do not set any environment variables, edit your sh
 
 ## Step 1 — Clone and run
 
+The fastest path is the one-command starter — it installs dependencies, launches the dashboard in the foreground, and tells you which agents it can see:
+
 ```bash
 git clone https://github.com/aanjaneyasinghdhoni/ClaudeSec.git
 cd ClaudeSec
+./start.sh
+```
+
+Prefer to run the steps yourself? They are equivalent:
+
+```bash
 corepack enable
 pnpm install
 pnpm dev

--- a/docs/reference/config.mdx
+++ b/docs/reference/config.mdx
@@ -12,6 +12,7 @@ All configuration is **optional** — ClaudeSec runs with sensible defaults and 
 | `CLAUDESEC_PORT` / `PORT` | `3000` | Dashboard + OTLP listen port |
 | `CLAUDESEC_HOST` | `127.0.0.1` | Bind address. Set `0.0.0.0` only for deliberate LAN access |
 | `CLAUDESEC_TOKEN` | — | Bearer token required for **non-loopback** API/MCP access; **required** to bind a non-loopback host (the server refuses to start otherwise). Loopback access is exempt |
+| `CLAUDESEC_TRUST_LOCAL` | — | Set `1` to disable the loopback-address auth check and trust all clients (opt-in; default off). Use **only** when host exposure is already restricted — e.g. Docker with a `127.0.0.1`-only port binding |
 | `CLAUDESEC_CORS_ORIGINS` | `localhost` | Comma-separated allowed CORS origins |
 | `CLAUDESEC_TRUST_PROXY` | — | Set `1` to trust `X-Forwarded-For` (behind a reverse proxy) |
 | `NODE_ENV` | — | `production` serves the built `dist/`; otherwise Vite dev mode |
@@ -22,6 +23,7 @@ All configuration is **optional** — ClaudeSec runs with sensible defaults and 
 |----------|---------|---------|
 | `CLAUDESEC_DB` | `spans.db` | SQLite database path. Point throwaway / test instances elsewhere to isolate them |
 | `CLAUDESEC_ALLOW_RESET` | — | Must be `1` to permit `POST /api/reset`; the destructive data-wipe is disabled by default |
+| `CLAUDESEC_SEED_DEMO` | — | Set `1` to seed an **empty** database once with synthetic demo sessions on startup. Used by the isolated demo container; never touches a database that already has data |
 
 ## Enforcement
 
@@ -32,6 +34,7 @@ These configure the opt-in [Enforcement](/security/enforcement) PreToolUse hook.
 | `CLAUDESEC_MODE` | `monitor` | Hook mode: `monitor` logs would-blocks (default), `enforce` blocks high-severity tool calls |
 | `CLAUDESEC_HOOKS_BYPASS` | — | Set `1` in the hook's environment to allow everything for one invocation (escape hatch) |
 | `CLAUDESEC_ENFORCE_CONFIG` | `enforce-config.json` | Path to the mirrored enforce-config file the hook reads (fail-open if absent) |
+| `CLAUDESEC_ENFORCE_RULES` | `rules-enforcement.json` | Path to the compiled block-rule snapshot the hook and MCP proxy evaluate against |
 
 ## MCP / skill scanner
 
@@ -52,6 +55,10 @@ These configure the opt-in [Enforcement](/security/enforcement) PreToolUse hook.
 |----------|---------|---------|
 | `CLAUDESEC_DISABLE_SCRUB` | — | Set `1` to store raw, unscrubbed attributes (not recommended) |
 | `CLAUDESEC_HONEYTOKENS` | — | Comma-separated canary strings; any span containing one fires a HIGH exfiltration alert |
+| `CLAUDESEC_JUDGE_URL` | — | Optional [LLM-as-judge](/how-to/local-llm) endpoint (OpenAI-compatible `/chat/completions`; e.g. local Ollama `http://localhost:11434/v1`). **Unset = off, no outbound calls.** Loopback allowed; non-loopback is SSRF-guarded |
+| `CLAUDESEC_JUDGE_MODEL` | `llama3.1` | Model name passed to the judge endpoint |
+| `CLAUDESEC_JUDGE_KEY` | — | Optional bearer key for the judge endpoint (not needed for local Ollama / LM Studio) |
+| `CLAUDESEC_JUDGE_TIMEOUT_MS` | `8000` | Per-request judge timeout in milliseconds (capped at 60000) |
 
 ## Retention
 
@@ -67,6 +74,7 @@ These configure the opt-in [Enforcement](/security/enforcement) PreToolUse hook.
 | `CLAUDESEC_RATE_LIMIT_RPS` | `50` | Max OTLP requests/second per IP |
 | `CLAUDESEC_RATE_LIMIT_BURST` | `200` | Token-bucket burst capacity |
 | `CLAUDESEC_MAX_SPANS_BATCH` | `500` | Max spans allowed per OTLP batch |
+| `CLAUDESEC_GRAPH_LIMIT` | `2000` | How many of the most-recent spans the live graph renders. Older spans are **not** deleted — they stay available via Search and Sessions. See [Data retention](/explanation/retention) |
 
 ## Alerts & integrations
 

--- a/docs/security/privacy.mdx
+++ b/docs/security/privacy.mdx
@@ -8,7 +8,10 @@ ClaudeSec sees your agents' commands, prompts, and code. It is built so none of 
 ## Local-first guarantees
 
 - **Loopback only** — the server binds `127.0.0.1` by default. Set `CLAUDESEC_HOST=0.0.0.0` only if you deliberately want LAN access, and only on a trusted network (ClaudeSec is unauthenticated by design).
-- **No egress** — nothing is sent anywhere. The single optional outbound path is `OTEL_FORWARD_URL`, off unless you set it, and SSRF-blocked for private ranges.
+- **No egress** — nothing is sent anywhere unless you opt in. There are three optional outbound paths, all off unless set:
+  - `OTEL_FORWARD_URL` — forwards received OTLP traces to an upstream collector. SSRF-guarded (private and loopback ranges blocked).
+  - `CLAUDESEC_WEBHOOK_URL` — delivers alerts to a Slack / Discord / generic JSON endpoint. SSRF-guarded (private and loopback ranges blocked).
+  - `CLAUDESEC_JUDGE_URL` — the optional [LLM-as-judge](/how-to/local-llm). SSRF-guarded for non-loopback URLs; loopback is allowed so the judge can run fully on-device (the recommended no-egress setup).
 - **Owner-only database** — `spans.db` is created with `0600` permissions (owner read/write only).
 - **Username scrubbing** — process command lines and OS usernames are masked (`/Users/***`, `user: ***`) before being shown or exported.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,10 @@ tags:
     description: Multi-agent orchestration data
   - name: Export
     description: Data export and reset
+  - name: Health
+    description: Server health and Prometheus metrics
+  - name: MCP
+    description: Model Context Protocol JSON-RPC endpoint
 
 paths:
   /v1/traces:
@@ -539,6 +543,90 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StatusOk'
+
+  /api/health:
+    get:
+      tags: [Health]
+      summary: Server health and counts
+      description: |
+        Returns server status, version, uptime, and aggregate counts (spans,
+        threats, sessions, alerts), plus database size, retention settings, rate
+        limiting, OTLP forwarding state, and auto-export state.
+      responses:
+        '200':
+          description: Health snapshot
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:        { type: string, example: ok }
+                  version:       { type: string, example: 1.0.0 }
+                  uptime:        { type: number, description: Uptime in seconds }
+                  spansTotal:    { type: integer }
+                  threatsTotal:  { type: integer }
+                  sessionsTotal: { type: integer }
+                  alertsTotal:   { type: integer }
+                  dbSizeBytes:   { type: integer }
+
+  /metrics:
+    get:
+      tags: [Health]
+      summary: Prometheus metrics
+      description: |
+        Prometheus text exposition format. Exposes `spans_total`,
+        `threats_total`, `tokens_in_total` and `tokens_out_total` (by harness),
+        `sessions_total`, `alerts_total`, and `uptime_seconds`.
+      responses:
+        '200':
+          description: Prometheus metrics
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: |
+                # HELP spans_total Total spans ingested
+                # TYPE spans_total counter
+                spans_total{harness="claude-code"} 128
+                uptime_seconds 3600
+
+  /mcp:
+    post:
+      tags: [MCP]
+      summary: Model Context Protocol (JSON-RPC 2.0)
+      description: |
+        JSON-RPC 2.0 endpoint for AI-to-AI access. Supports the `initialize`,
+        `tools/list`, and `tools/call` methods, exposing 11 tools (e.g.
+        `get_incident_summary`, `get_alerts`, `search_spans`) so another agent can
+        query ClaudeSec's security data for triage. See the MCP integration docs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [jsonrpc, method]
+              properties:
+                jsonrpc: { type: string, example: '2.0' }
+                id:      { type: integer, example: 1 }
+                method:  { type: string, example: tools/list }
+                params:  { type: object }
+            example:
+              jsonrpc: '2.0'
+              id: 1
+              method: tools/list
+              params: {}
+      responses:
+        '200':
+          description: JSON-RPC 2.0 response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  jsonrpc: { type: string, example: '2.0' }
+                  id:      { type: integer, example: 1 }
+                  result:  { type: object }
 
 components:
   schemas:

--- a/server/index.ts
+++ b/server/index.ts
@@ -2088,6 +2088,7 @@ service:
       { key: 'CLAUDESEC_RATE_LIMIT_RPS',    description: 'Max OTLP requests per second per IP',     default: '50',     category: 'Performance' },
       { key: 'CLAUDESEC_RATE_LIMIT_BURST',   description: 'Token bucket burst capacity',              default: '200',    category: 'Performance' },
       { key: 'CLAUDESEC_MAX_SPANS_BATCH',    description: 'Max spans allowed per OTLP batch',         default: '500',    category: 'Performance' },
+      { key: 'CLAUDESEC_GRAPH_LIMIT',        description: 'How many of the most-recent spans the live graph renders (older spans stay available via Search/Sessions)', default: '2000', category: 'Performance' },
       { key: 'CLAUDESEC_MAX_SPANS',          description: 'Total span capacity before pruning',       default: '50000',  category: 'Retention' },
       { key: 'CLAUDESEC_RETENTION_DAYS',     description: 'Days to keep data before age-based prune', default: '30',     category: 'Retention' },
       { key: 'CLAUDESEC_WEBHOOK_URL',        description: 'Webhook endpoint for alert delivery',      default: '',       category: 'Alerts',   sensitive: true },
@@ -2104,6 +2105,7 @@ service:
       { key: 'CLAUDESEC_JUDGE_URL',          description: 'Optional LLM-as-judge endpoint (OpenAI-compatible /chat/completions; recommended: local Ollama http://localhost:11434/v1). OFF by default.', default: '', category: 'Detection' },
       { key: 'CLAUDESEC_JUDGE_MODEL',        description: 'Model name for the LLM-as-judge (e.g. llama3.1)',           default: 'llama3.1', category: 'Detection' },
       { key: 'CLAUDESEC_JUDGE_KEY',          description: 'Optional bearer key for the judge endpoint (not needed for local Ollama)', default: '', category: 'Detection', sensitive: true },
+      { key: 'CLAUDESEC_JUDGE_TIMEOUT_MS',   description: 'Per-request LLM-as-judge timeout in milliseconds (capped at 60000)', default: '8000', category: 'Detection' },
     ];
 
     const enriched = envVars.map(v => ({


### PR DESCRIPTION
## Summary

Bring the documentation fully in line with the current codebase and fill the gaps a full A-to-Z audit surfaced.

## Accuracy fixes
- Correct the outbound-path claim in `docs/index.mdx`, `docs/security/privacy.mdx`, and `README.md` — there are **three** optional outbound paths (`OTEL_FORWARD_URL`, `CLAUDESEC_WEBHOOK_URL`, `CLAUDESEC_JUDGE_URL`), all off unless set and SSRF-guarded.
- Fix the stale excessive-tool-calls threshold and add the transcript watcher to the architecture data-flow diagram.
- Update `.github/CONTRIBUTING.md` to the current `server/detection.ts` rule layout and lowercase severities.
- Replace `npx claudesec init` with `node cli/init.mjs` in the changelog.

## New docs
- `docs/how-to/local-llm.mdx` — using a local model (Ollama / LM Studio) for the optional LLM-as-judge.
- `docs/explanation/retention.mdx` — how data retention and dashboard capacity work (your data is kept; the graph shows a recent window; how to tune for heavy use).
- A "Why an MCP server?" intro in `docs/mcp.mdx`.

## Coverage
- `docs/reference/config.mdx`: document 8 previously-undocumented environment variables.
- `openapi.yaml`: add `POST /mcp`, `GET /api/health`, `GET /metrics`.
- Surface `./start.sh` as the primary one-command option in the getting-started docs.
- The in-app Settings env reference now lists the judge-timeout and graph-limit variables.

## Verification

`pnpm preflight` (lint, test, build, consistency, audit) and a local CodeQL run pass.
