### PR TITLE
feat: price Claude Fable 5 in the cost table

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -869,6 +869,7 @@ async function fireWebhook(alert: {
 
 const MODEL_PRICING: Record<string, { inputPer1M: number; outputPer1M: number; label: string }> = {
   // Claude
+  'claude-fable-5':       { inputPer1M: 10,    outputPer1M: 50,    label: 'Claude Fable 5' },
   'claude-opus-4-8':      { inputPer1M: 5,     outputPer1M: 25,    label: 'Claude Opus 4.8' },
   'claude-opus-4-7':      { inputPer1M: 5,     outputPer1M: 25,    label: 'Claude Opus 4.7' },
   'claude-opus-4-6':      { inputPer1M: 5,     outputPer1M: 25,    label: 'Claude Opus 4.6' },


### PR DESCRIPTION
## What

Add Claude Fable 5 to the cost-estimation pricing table at its published rates — $10 / MTok input, $50 / MTok output.

## Why

Without a row for it, Fable 5 spans fell through to the unknown-model path and showed `$0`. This prices them correctly. Prompt-cache tokens are handled automatically: the cost route derives cache-write (×1.25) and cache-read (×0.1) from the input rate, so no extra columns are needed.

## Notes

- Every other Claude row already matches current pricing, so this is the only addition.
- Dated variants (e.g. `claude-fable-5-…`) resolve through the existing prefix match in `lookupPricing`.
