### PR TITLE
docs: note Claude Fable 5 pricing in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Project governance and release-process documentation (`.github/GOVERNANCE.md`
   and `.github/RELEASING.md`) describing roles, decision-making, and how versioned
   releases are cut.
+- Cost tracking for Claude Fable 5, priced at its published rates ($10 / 1M input,
+  $50 / 1M output). Prompt-cache tokens are derived from the input rate, so cache
+  reads and writes are costed automatically. Spans from Fable 5 sessions now show
+  real costs instead of `$0`.
 
 ### Changed
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gate, and — only after you confirm — commits, tags, pushes, and publishes the
   GitHub Release. It refuses to run on a dirty or out-of-date tree and never
   force-pushes.
+- **Claude Fable 5 pricing** — the cost table now prices Claude Fable 5 at its
+  published rates ($10 / 1M input, $50 / 1M output), so spans from Fable 5 sessions
+  show real costs instead of `$0`. Prompt-cache tokens are derived from the input
+  rate, so cache reads and writes are costed automatically.
 
 ### Changed
 


### PR DESCRIPTION
Records the Claude Fable 5 cost-table addition (shipped in #49) in both changelogs under Unreleased — the root `CHANGELOG.md` and the in-app `docs/changelog.mdx` — at its published rates ($10 / 1M input, $50 / 1M output).