### PR TITLE
fix: include cli/ in the Docker build context so the image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,11 @@
 # Build-context excludes — keep the image small and free of local data.
 node_modules
 dist
-.git
-.gitignore
-.dockerignore
+
+# Hidden files and directories (VCS, CI config, editor and local tool state)
+# are never part of the image. The build needs none of them. The pattern is
+# `.?*` rather than `.*` so it cannot match `.` itself (the COPY source).
+.?*
 
 # Local data, env, secrets, and runtime artifacts — never bake into the image
 *.db
@@ -20,7 +22,11 @@ rules.json
 enforce-config.json
 rules-enforcement.json
 
-# Markdown, API spec, and CLI are not needed at container runtime
+# Markdown and the API spec are not needed at container runtime.
+# cli/ must stay in the context: the image build runs the test gate, and
+# catastrophic-parity requires cli/hooks/claudesec-enforce.cjs to stay in
+# lockstep with the server rules. The runtime stage copies an explicit set
+# of paths (Dockerfile stage 2) that does not include cli/, so the CLI
+# still never ships in the final image.
 *.md
 openapi.yaml
-cli/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The container image failed to build from a version tag: the Docker build
+  context excluded `cli/`, but the build's test gate checks
+  `cli/hooks/claudesec-enforce.cjs` for catastrophic-rule parity and fails
+  hard when it is missing. The build context now includes `cli/`. The
+  runtime image is unchanged — the CLI still does not ship in the container.
+
+### Security
+
+- The Docker build context now excludes all hidden files and directories, so
+  VCS, CI, editor, and local tool state can never reach an image layer.
+
 ## [1.2.0] - 2026-06-10
 
 ### Added


### PR DESCRIPTION
## Problem

The v1.2.0 tag's **Release image** workflow failed before publishing an image. The Docker builder stage runs `pnpm build`, which runs the test gate, and the catastrophic-parity test requires `cli/hooks/claudesec-enforce.cjs` — a tracked file that must stay in lockstep with the server rules. `.dockerignore` excluded `cli/` from the build context, so the test failed inside the container and the build exited 1.

## Fix

- Stop excluding `cli/` from the Docker build context. The runtime stage copies an explicit set of paths that does not include `cli/`, so the CLI still never ships in the final image (verified by listing `/app` in a locally built image).
- Exclude all hidden files and directories (`.?*`) from the context — the build needs none of them, and VCS/CI/editor/tool state should never reach an image layer. The pattern is `.?*` rather than `.*` so BuildKit's lint does not flag the `COPY . .` source as ignored.

## Verification

- Local `docker build` of both the builder stage and the full image passes; the builder contains `cli/hooks/claudesec-enforce.cjs` and no hidden entries; the final image is byte-identical in layout to before (no `cli/`, no hidden files).
- Full local test suite and build pass.