### PR TITLE
fix: run the image test gate on native hardware, not under emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The multi-architecture image build failed on the emulated platform: the test
+  gate includes wall-clock ReDoS timing assertions, and on a QEMU-emulated CPU
+  every pattern exceeds the timing budget. The test gate and frontend build now
+  run once on the build platform's native architecture; the per-architecture
+  stages only compile native dependencies and assemble the runtime image.
+
 ## [1.2.1] - 2026-06-11
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# ── Stage 1: Build frontend ──────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+# ── Stage 1: Target-arch dependencies ────────────────────────────────────────
+# Runs once per target platform so native modules (better-sqlite3, re2) are
+# compiled for the architecture the image will actually run on.
+FROM node:22-alpine AS deps
 WORKDIR /app
 
 # Enable corepack so pnpm is available without a global install
@@ -8,10 +10,23 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
+# ── Stage 2: Test gate + frontend build ──────────────────────────────────────
+# Pinned to the build platform so it runs on native hardware exactly once.
+# The test gate includes wall-clock ReDoS timing assertions that fail under
+# QEMU emulation (every pattern looks "slow" on an emulated CPU); the vite
+# output is plain JS/CSS and identical for every architecture anyway.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
 COPY . .
 RUN pnpm build
 
-# ── Stage 2: Production image ────────────────────────────────────────────────
+# ── Stage 3: Production image ────────────────────────────────────────────────
 FROM node:22-alpine
 WORKDIR /app
 
@@ -20,11 +35,11 @@ RUN apk add --no-cache procps su-exec && corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# Reuse the native binaries already compiled in the builder stage — avoids
+# Reuse the native binaries already compiled in the deps stage — avoids
 # re-running node-gyp for better-sqlite3 / re2 in a minimal prod image.
 # pnpm's node_modules layout (including the .pnpm store) uses relative symlinks
 # and is fully self-contained, so copying the whole directory is safe.
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=deps /app/node_modules ./node_modules
 
 # Copy backend TypeScript modules + tsconfig so tsx can resolve all imports.
 COPY server/ ./server/


### PR DESCRIPTION
## Problem

The v1.2.1 tag's **Release image** workflow got further than v1.2.0's but failed on the `linux/arm64` leg: the build runs the test gate, whose ReDoS check asserts a wall-clock budget per rule pattern. On the amd64 runner the arm64 stage executes under QEMU emulation, where every pattern exceeds the budget — all 456 rules "failed" while the amd64 leg passed all 456.

## Fix

Split the builder stage by concern:

- **deps** (per target arch): `pnpm install` only, so the native modules (`better-sqlite3`, `re2`) are compiled for the architecture the image runs on. The runtime stage copies `node_modules` from here.
- **builder** (`FROM --platform=$BUILDPLATFORM`): test gate + `vite build`, executed once on native hardware. The runtime stage copies only `dist/` from here — plain JS/CSS, identical for every architecture.

Timing assertions now always run at native speed, and the emulated leg does strictly less work than before.

## Verification

- Local `docker buildx build --platform linux/amd64,linux/arm64` passes end-to-end (one native leg, one emulated leg — the same mix as CI, with the architectures swapped).
- Full local test suite and build pass.